### PR TITLE
change triage queries to only find bugs whose component changed within the range

### DIFF
--- a/js/triage.js
+++ b/js/triage.js
@@ -162,8 +162,7 @@ function setupQueryURLs(url, seeall)
         return i;
       }
     }
-    bugQueries[i]["url"] = url + ("&chfieldfrom=" + bugQueries[i].from +
-                                  "&chfieldto=" + bugQueries[i].to);
+    bugQueries[i]["url"] = url.replace(/<FROM>/g, bugQueries[i].from).replace(/<TO>/g, bugQueries[i].to);
   }
   return bugQueries.length;
 }

--- a/js/triage.json
+++ b/js/triage.json
@@ -2,7 +2,7 @@
 "triage" : {
   "BUGZILLA_URL": "https://bugzilla.mozilla.org/buglist.cgi",
   "BUGZILLA_REST_URL": "https://bugzilla.mozilla.org/rest/bug",
-  "basequery" : "?keywords=intermittent-failure&keywords_type=nowords&f1=status_whiteboard&o1=notsubstring&emailtype1=exact&chfield=%5BBug%20creation%5D&emailassigned_to1=1&query_format=advanced&bug_status=UNCONFIRMED&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&email1=nobody%40mozilla.org&priority=--&component=Canvas%3A%202D&component=Canvas%3A%20WebGL&component=GFX%3A%20Color%20Management&component=Graphics&component=Graphics%3A%20Layers&component=Graphics%3A%20Text&component=Image%20Blocking&component=ImageLib&product=Core",
+  "basequery" : "?keywords=intermittent-failure&keywords_type=nowords&f1=status_whiteboard&o1=notsubstring&emailtype1=exact&emailassigned_to1=1&query_format=advanced&bug_status=UNCONFIRMED&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&email1=nobody%40mozilla.org&priority=--&component=Canvas%3A%202D&component=Canvas%3A%20WebGL&component=GFX%3A%20Color%20Management&component=Graphics&component=Graphics%3A%20Layers&component=Graphics%3A%20Text&component=Image%20Blocking&component=ImageLib&product=Core&n2=1&n7=1&o2=changedafter&o4=changedafter&j3=OR&v2=<TO>&v4=<FROM>&f10=CP&o7=changedafter&v6=<FROM>&f8=CP&j5=AND_G&o6=changedafter&v7=<TO>&f4=component&f3=OP&f2=component&f5=OP&f6=creation_ts&f7=creation_ts",
   "bugQueries": {
    "2015" : [
      {"who":"Milan", "from":"2015-1-3", "to":"2015-1-9"},
@@ -240,6 +240,6 @@
 "tracking" : {
   "BUGZILLA_URL": "https://bugzilla.mozilla.org/buglist.cgi",
   "BUGZILLA_REST_URL": "https://bugzilla.mozilla.org/rest/bug",
-  "basequery" : "?keywords=intermittent-failure&keywords_type=nowords&f1=status_whiteboard&o1=notsubstring&emailtype1=exact&chfield=%5BBug%20creation%5D&emailassigned_to1=1&query_format=advanced&bug_status=UNCONFIRMED&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&email1=nobody%40mozilla.org&priority=--&component=Canvas%3A%202D&component=Canvas%3A%20WebGL&component=GFX%3A%20Color%20Management&component=Graphics&component=Graphics%3A%20Layers&component=Graphics%3A%20Text&component=Image%20Blocking&component=ImageLib&component=Panning%20and%20Zooming&product=Core"
+  "basequery" : "?keywords=intermittent-failure&keywords_type=nowords&f1=status_whiteboard&o1=notsubstring&emailtype1=exact&emailassigned_to1=1&query_format=advanced&bug_status=UNCONFIRMED&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&email1=nobody%40mozilla.org&priority=--&component=Canvas%3A%202D&component=Canvas%3A%20WebGL&component=GFX%3A%20Color%20Management&component=Graphics&component=Graphics%3A%20Layers&component=Graphics%3A%20Text&component=Image%20Blocking&component=ImageLib&component=Panning%20and%20Zooming&product=Core&n2=1&n7=1&o2=changedafter&o4=changedafter&j3=OR&v2=<TO>&v4=<FROM>&f10=CP&o7=changedafter&v6=<FROM>&f8=CP&j5=AND_G&o6=changedafter&v7=<TO>&f4=component&f3=OP&f2=component&f5=OP&f6=creation_ts&f7=creation_ts"
  }
 }


### PR DESCRIPTION
The original query setup only looked for bugs whose creation date was within the range AND in a gfx component. This creates the problem that bugs created outside a gfx component but then later changed into one can then backfill a person's triage queue way after their triage week is up.

This modifies the query so that it searches for bugs satisfying one of the following:
1) The bug was created in or changed to a gfx component during the triage week but whose component was never changed after
2) The bug was neither created during the triage week nor in a gfx component, but was later changed to a gfx component during the triage week with no further change to the component

This ensures that a person's triage queue will never backfill with bugs created within that week but hidden by being in the wrong component. The last time the bug gets changed to a gfx component effectively becomes the triage date, so bugs will only ever get bumped to the current triage week, not earlier weeks.